### PR TITLE
Resolves the Current Payload without monkeypatching

### DIFF
--- a/src-api/resolvers/Connections.js
+++ b/src-api/resolvers/Connections.js
@@ -13,23 +13,28 @@ export const Query = {
     }
 }
 
+var once = true;
+
 export const Subscription = {
 
     instructions: {
+        resolve: (payload, args, { currentPlayer }, info) => currentPlayer,
         subscribe(_, args, { pubsub, currentPlayer }) {
 
             if (!currentPlayer) {
                 throw new Error('a player must be logged in to subscribe to instructions')
             }
 
-            const iterator = pubsub.asyncIterator('new-instructions')
-            const next = iterator.next
-            iterator.next = () => next()
-                .then(() => ({ value: { instructions: currentPlayer } }))
-
-            return iterator
-
+            return pubsub.asyncIterator('new-instructions')
         }
     }
 
 }
+
+
+// returnpubsub.asyncIterator('new-instructions')
+//             const next = iterator.next
+//             iterator.next = () => next()
+//                 .then(() => ({ value: { instructions: currentPlayer } }))
+
+//             return iterator


### PR DESCRIPTION
Subscriptions have a `resolve` method that can be used to customize the payload returned to each subscriber. In our case we can use the `resolve` method to return the `currentPlayer` to each subscriber when a `new-instructions` event is raised. This means that we don't have to monkey patch to send each connection a unique set of instructions